### PR TITLE
Add image pull secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .cpcache
 .nrepl-port
+.clj-kondo/
+.calva/output-window/output.calva-repl
+.lsp/.cache/db.transit.json

--- a/src/nos/ops/docker.clj
+++ b/src/nos/ops/docker.clj
@@ -508,7 +508,7 @@
   [{op-id :id}
    {flow-id :id}
    {:keys [image cmds conn artifacts resources workdir entrypoint env inline-logs? stdout?
-           artifact-path image-pull-secret]
+           artifact-path image_pull_secrets]
     :or   {conn          {:uri "http://localhost:8080"}
            workdir       "/root"
            entrypoint    nil
@@ -517,9 +517,9 @@
            artifact-path (str "/tmp/nos-artifacts/" flow-id)
            inline-logs?  false
            stdout?       false
-           image-pull-secret          nil}}]
+           image_pull_secrets          nil}}]
   (f/try-all [_ (log/tracef "Trying to pull %s... " image)
-              _ (docker-pull conn image image-pull-secret)
+              _ (docker-pull conn image image_pull_secrets)
 
               client (c/client {:engine   :podman
                                 :category :libpod/containers

--- a/src/nos/ops/docker.clj
+++ b/src/nos/ops/docker.clj
@@ -167,6 +167,7 @@
                           :category :libpod/images
                           :conn conn
                           :version api-version})]
+    (println "Pulling image " image " with secret " image-pull-secret)
     (c/invoke client {:op :ImagePullLibpod
                       :params {:reference image
                                :X-Registry-Auth (-> image-pull-secret json/encode b64-encode)}

--- a/src/nos/ops/docker.clj
+++ b/src/nos/ops/docker.clj
@@ -162,15 +162,15 @@
   [to-encode]
   (.encodeToString (Base64/getEncoder) (.getBytes to-encode)))
 
-(defn docker-pull [conn image image-pull-secret]
+(defn docker-pull [conn image image_pull_secrets]
   (let [client (c/client {:engine :podman
                           :category :libpod/images
                           :conn conn
                           :version api-version})]
-    (println "Pulling image " image " with secret " image-pull-secret)
+    (println "Pulling image " image " with secret " image_pull_secrets)
     (c/invoke client {:op :ImagePullLibpod
                       :params {:reference image
-                               :X-Registry-Auth (-> image-pull-secret json/encode b64-encode)}
+                               :X-Registry-Auth (-> image_pull_secrets json/encode b64-encode)}
                       :throw-exceptions true})))
 
 (defn commit-container

--- a/src/nos/ops/docker.clj
+++ b/src/nos/ops/docker.clj
@@ -162,15 +162,15 @@
   [to-encode]
   (.encodeToString (Base64/getEncoder) (.getBytes to-encode)))
 
-(defn docker-pull [conn image image_pull_secrets]
+(defn docker-pull [conn image image-pull-secret]
   (let [client (c/client {:engine :podman
                           :category :libpod/images
                           :conn conn
                           :version api-version})]
-    (println "Pulling image " image " with secret " image_pull_secrets)
+    (println "Pulling image " image " with secret " image-pull-secret)
     (c/invoke client {:op :ImagePullLibpod
                       :params {:reference image
-                               :X-Registry-Auth (-> image_pull_secrets json/encode b64-encode)}
+                               :X-Registry-Auth (-> image-pull-secret json/encode b64-encode)}
                       :throw-exceptions true})))
 
 (defn commit-container
@@ -508,7 +508,7 @@
   [{op-id :id}
    {flow-id :id}
    {:keys [image cmds conn artifacts resources workdir entrypoint env inline-logs? stdout?
-           artifact-path image_pull_secrets]
+           artifact-path image-pull-secret]
     :or   {conn          {:uri "http://localhost:8080"}
            workdir       "/root"
            entrypoint    nil
@@ -517,9 +517,9 @@
            artifact-path (str "/tmp/nos-artifacts/" flow-id)
            inline-logs?  false
            stdout?       false
-           image_pull_secrets          nil}}]
+           image-pull-secret          nil}}]
   (f/try-all [_ (log/tracef "Trying to pull %s... " image)
-              _ (docker-pull conn image image_pull_secrets)
+              _ (docker-pull conn image image-pull-secret)
 
               client (c/client {:engine   :podman
                                 :category :libpod/containers

--- a/src/nos/ops/docker.clj
+++ b/src/nos/ops/docker.clj
@@ -16,7 +16,8 @@
            [java.util Arrays]
            [org.apache.commons.compress.archivers.tar TarArchiveOutputStream TarArchiveInputStream]
            [org.apache.commons.io FilenameUtils]
-           [org.apache.commons.compress.utils IOUtils]))
+           [org.apache.commons.compress.utils IOUtils]
+           [java.util Base64]))
 
 (def api-version "v4.0.0")
 
@@ -156,13 +157,19 @@
         (conj args current-arg)
         args))))
 
-(defn docker-pull [conn image]
+(defn b64-encode
+  "Encodes a string to base64."
+  [to-encode]
+  (.encodeToString (Base64/getEncoder) (.getBytes to-encode)))
+
+(defn docker-pull [conn image auth]
   (let [client (c/client {:engine :podman
                           :category :libpod/images
                           :conn conn
                           :version api-version})]
     (c/invoke client {:op :ImagePullLibpod
-                      :params {:reference image}
+                      :params {:reference image
+                               :X-Registry-Auth (-> auth json/encode b64-encode)}
                       :throw-exceptions true})))
 
 (defn commit-container
@@ -500,7 +507,7 @@
   [{op-id :id}
    {flow-id :id}
    {:keys [image cmds conn artifacts resources workdir entrypoint env inline-logs? stdout?
-           artifact-path]
+           artifact-path auth]
     :or   {conn          {:uri "http://localhost:8080"}
            workdir       "/root"
            entrypoint    nil
@@ -508,9 +515,10 @@
            artifacts     []
            artifact-path (str "/tmp/nos-artifacts/" flow-id)
            inline-logs?  false
-           stdout?       false}}]
+           stdout?       false
+           auth          nil}}]
   (f/try-all [_ (log/tracef "Trying to pull %s... " image)
-              _ (docker-pull conn image)
+              _ (docker-pull conn image auth)
 
               client (c/client {:engine   :podman
                                 :category :libpod/containers

--- a/src/nos/ops/docker.clj
+++ b/src/nos/ops/docker.clj
@@ -167,7 +167,6 @@
                           :category :libpod/images
                           :conn conn
                           :version api-version})]
-    (println "Pulling image " image " with secret " image-pull-secret)
     (c/invoke client {:op :ImagePullLibpod
                       :params {:reference image
                                :X-Registry-Auth (-> image-pull-secret json/encode b64-encode)}


### PR DESCRIPTION
Add auth to the docker-pull op.
It is base64 encoded and passed as a json to the `X-Registry-Auth` property of the header.

